### PR TITLE
fix: resolve CAPTCHA login flow (issue #31)

### DIFF
--- a/custom_components/fusion_solar_app/__init__.py
+++ b/custom_components/fusion_solar_app/__init__.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -41,14 +41,18 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     # Perform an initial data load from api.
     # async_config_entry_first_refresh() is special in that it does not log errors if it fails.
     # ConfigEntryAuthFailed will propagate up and trigger HA's reauth flow.
-    try:
-        await coordinator.async_config_entry_first_refresh()
-    except ConfigEntryAuthFailed:
-        raise
+    await coordinator.async_config_entry_first_refresh()
 
     # Test to see if api initialised correctly, else raise ConfigNotReady to make HA retry setup
     if not coordinator.api.connected:
         raise ConfigEntryNotReady
+
+    # Session is now live in memory — clear stale token from persistent storage
+    if "dp_session" in config_entry.data:
+        hass.config_entries.async_update_entry(
+            config_entry,
+            data={k: v for k, v in config_entry.data.items() if k not in ("dp_session", "data_host")},
+        )
 
     # Initialise a listener for config flow options changes.
     # See config_flow for defining an options setting that shows up as configure on the integration.

--- a/custom_components/fusion_solar_app/__init__.py
+++ b/custom_components/fusion_solar_app/__init__.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -39,11 +39,14 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     coordinator = FusionSolarCoordinator(hass, config_entry)
 
     # Perform an initial data load from api.
-    # async_config_entry_first_refresh() is special in that it does not log errors if it fails
-    await coordinator.async_config_entry_first_refresh()
+    # async_config_entry_first_refresh() is special in that it does not log errors if it fails.
+    # ConfigEntryAuthFailed will propagate up and trigger HA's reauth flow.
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except ConfigEntryAuthFailed:
+        raise
 
     # Test to see if api initialised correctly, else raise ConfigNotReady to make HA retry setup
-    # TODO: Change this to match how your api will know if connected or successful update
     if not coordinator.api.connected:
         raise ConfigEntryNotReady
 

--- a/custom_components/fusion_solar_app/api.py
+++ b/custom_components/fusion_solar_app/api.py
@@ -315,14 +315,17 @@ class FusionSolarAPI:
 
 
     def restore_session(self, dp_session: str, data_host: str) -> None:
-        """Restore an authenticated session without requiring login."""
+        """Restore an authenticated session without requiring login.
+
+        Does NOT make HTTP calls — safe to call from the event loop.
+        CSRF is refreshed lazily on the next API call that needs it.
+        """
         self.dp_session = dp_session
         self.data_host = data_host
         self.session.cookies.set("dp-session", dp_session)
         self.session.cookies.set("locale", "en-us")
         self.connected = True
         self.last_session_time = datetime.now(timezone.utc)
-        self.refresh_csrf()
         self._start_session_monitor()
 
     def reset_session(self):
@@ -352,18 +355,11 @@ class FusionSolarAPI:
                 "accept-encoding": "gzip, deflate, br, zstd",
                 "Referer": f"https://{self.data_host}{DATA_REFERER_URL}",
             }
-            roarand_cookies = {
-                "locale": "en-us",
-                "dp-session": self.dp_session,
-            }
-            roarand_params = {}
-    
+
             _LOGGER.debug("Getting Roarand at: %s", roarand_url)
             roarand_response = self.session.get(
                 roarand_url,
                 headers=roarand_headers,
-                cookies=roarand_cookies,
-                params=roarand_params,
                 timeout=20,
             )
     
@@ -408,12 +404,7 @@ class FusionSolarAPI:
             "Referer": f"https://{self.data_host}{DATA_REFERER_URL}",
             "Roarand": f"{self.csrf}",
         }
-    
-        station_cookies = {
-            "locale": "en-us",
-            "dp-session": self.dp_session,
-        }
-    
+
         station_payload = {
             "curPage": 1,
             "pageSize": 10,
@@ -424,13 +415,12 @@ class FusionSolarAPI:
             "sortDir": "DESC",
             "locale": "en_US",
         }
-    
+
         _LOGGER.debug("Getting Station at: %s", station_url)
         station_response = self.session.post(
             station_url,
             json=station_payload,
             headers=station_headers,
-            cookies=station_cookies,
             timeout=20,
         )
     
@@ -460,24 +450,19 @@ class FusionSolarAPI:
     def get_devices(self) -> list[Device]:
         self.refresh_csrf()
 
-        cookies = {
-            "locale": "en-us",
-            "dp-session": self.dp_session,
-        }
-        
         headers = {
             "Accept": "application/json",
             "Accept-Encoding": "gzip, deflate, br, zstd",
             "Accept-Language": "en-GB,en;q=0.9",
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
         }
-        
+
         # Fusion Solar App Station parameter
         params = {"stationDn": unquote(self.station)}
-        
+
         data_access_url = f"https://{self.data_host}{DATA_URL}"
         _LOGGER.debug("Getting Data at: %s", data_access_url)
-        response = self.session.get(data_access_url, headers=headers, cookies=cookies, params=params)
+        response = self.session.get(data_access_url, headers=headers, params=params)
 
         output = {
             "panel_production_power": 0.0,
@@ -797,11 +782,6 @@ class FusionSolarAPI:
             timestamp = first_day_of_year.timestamp() * 1000
             dateStr = first_day_of_year.strftime("%Y-%m-%d %H:%M:%S")
         
-        cookies = {
-            "locale": "en-us",
-            "dp-session": self.dp_session,
-        }
-        
         headers = {
             "application/json": "text/plain, */*",
             "Accept-Encoding": "gzip, deflate, br, zstd",
@@ -821,10 +801,10 @@ class FusionSolarAPI:
              "dateStr": dateStr,
              "_": int(timestampNow)
         }
-         
+
         energy_balance_url = f"https://{self.data_host}{ENERGY_BALANCE_URL}?{urlencode(params)}"
         _LOGGER.debug("Getting Energy Balance at: %s", energy_balance_url)
-        energy_balance_response = self.session.get(energy_balance_url, headers=headers, cookies=cookies)
+        energy_balance_response = self.session.get(energy_balance_url, headers=headers)
         _LOGGER.debug("Energy Balance Response: %s", energy_balance_response.text)
         try:
             energy_balance_data = energy_balance_response.json()
@@ -893,6 +873,7 @@ class FusionSolarAPI:
                 self._renew_session()
                 if not self.connected:
                     _LOGGER.warning("Session monitor stopping: renewal failed")
+                    self._stop_event.set()
                     break
             self._stop_event.wait(60)
 

--- a/custom_components/fusion_solar_app/api.py
+++ b/custom_components/fusion_solar_app/api.py
@@ -314,6 +314,17 @@ class FusionSolarAPI:
         raise APIAuthError("Login failed.")
 
 
+    def restore_session(self, dp_session: str, data_host: str) -> None:
+        """Restore an authenticated session without requiring login."""
+        self.dp_session = dp_session
+        self.data_host = data_host
+        self.session.cookies.set("dp-session", dp_session)
+        self.session.cookies.set("locale", "en-us")
+        self.connected = True
+        self.last_session_time = datetime.now(timezone.utc)
+        self.refresh_csrf()
+        self._start_session_monitor()
+
     def reset_session(self):
         """Reset HTTP session, clearing all cookies."""
         self.session = requests.Session()

--- a/custom_components/fusion_solar_app/api.py
+++ b/custom_components/fusion_solar_app/api.py
@@ -114,6 +114,7 @@ class FusionSolarAPI:
         self._stop_event = threading.Event()
         self.csrf = None
         self.csrf_time = None
+        self.session = requests.Session()
 
     @property
     def controller_name(self) -> str:
@@ -123,11 +124,20 @@ class FusionSolarAPI:
 
     def login(self) -> bool:
         """Connect to api."""
-        
+
+        # Pre-warm session: visit login page to get session cookies.
+        # This mimics browser behavior and may avoid the CAPTCHA requirement.
+        login_page_url = f"https://{self.login_host}{LOGIN_FORM_URL}"
+        _LOGGER.debug("Pre-warming session by visiting login page: %s", login_page_url)
+        try:
+            self.session.get(login_page_url, timeout=20)
+        except Exception as ex:
+            _LOGGER.warning("Failed to pre-warm session: %s", ex)
+
         public_key_url = f"https://{self.login_host}{PUBKEY_URL}"
         _LOGGER.debug("Getting Public Key at: %s", public_key_url)
         
-        response = requests.get(public_key_url)
+        response = self.session.get(public_key_url)
         _LOGGER.debug("Pubkey Response Headers: %s\r\nResponse: %s", response.headers, response.text)
         try:
             pubkey_data = response.json()
@@ -177,7 +187,7 @@ class FusionSolarAPI:
         }
         
         _LOGGER.debug("Login Request to: %s", login_url)
-        response = requests.post(login_url, json=payload, headers=headers)
+        response = self.session.post(login_url, json=payload, headers=headers)
         _LOGGER.debug(
             "Login: Request Headers: %s\r\nResponse Headers: %s\r\nResponse: %s",
             headers,
@@ -221,11 +231,12 @@ class FusionSolarAPI:
                     and login_response["errorCode"] == "411"
                 ):
                     _LOGGER.warning("Captcha required.")
+                    self.set_captcha_img()
                     raise APIAuthCaptchaError("Login requires Captcha.")
                 else:
                     login_form_url = f"https://{self.login_host}{LOGIN_FORM_URL}"
                     _LOGGER.debug("Redirecting to Login Form: %s", login_form_url)
-                    response = requests.get(login_form_url)
+                    response = self.session.get(login_form_url)
                     _LOGGER.debug("Login Form Response: %s", response.text)
                     _LOGGER.debug("Login Form Response headers: %s", response.headers)
                     raise APIAuthError("Login response did not include redirect information.")
@@ -239,7 +250,7 @@ class FusionSolarAPI:
             }
     
             _LOGGER.debug("Redirect to: %s", redirect_url)
-            redirect_response = requests.get(redirect_url, headers=redirect_headers, allow_redirects=False)
+            redirect_response = self.session.get(redirect_url, headers=redirect_headers, allow_redirects=False)
             _LOGGER.debug("Redirect Response: %s", redirect_response.text)
             response_headers = redirect_response.headers
             location_header = response_headers.get("Location")
@@ -300,11 +311,19 @@ class FusionSolarAPI:
         raise APIAuthError("Login failed.")
 
 
+    def reset_session(self):
+        """Reset HTTP session, clearing all cookies."""
+        self.session = requests.Session()
+        self.connected = False
+        self.dp_session = ""
+        self.csrf = None
+        self.csrf_time = None
+
     def set_captcha_img(self):
         timestampNow = datetime.now().timestamp() * 1000
         captcha_request_url = f"https://{self.login_host}{CAPTCHA_URL}?timestamp={timestampNow}"
         _LOGGER.debug("Requesting Captcha at: %s", captcha_request_url)
-        response = requests.get(captcha_request_url)
+        response = self.session.get(captcha_request_url)
         
         if response.status_code == 200:
             self.captcha_img = f"data:image/png;base64,{base64.b64encode(response.content).decode('utf-8')}"
@@ -326,7 +345,7 @@ class FusionSolarAPI:
             roarand_params = {}
     
             _LOGGER.debug("Getting Roarand at: %s", roarand_url)
-            roarand_response = requests.get(
+            roarand_response = self.session.get(
                 roarand_url,
                 headers=roarand_headers,
                 cookies=roarand_cookies,
@@ -393,7 +412,7 @@ class FusionSolarAPI:
         }
     
         _LOGGER.debug("Getting Station at: %s", station_url)
-        station_response = requests.post(
+        station_response = self.session.post(
             station_url,
             json=station_payload,
             headers=station_headers,
@@ -444,7 +463,7 @@ class FusionSolarAPI:
         
         data_access_url = f"https://{self.data_host}{DATA_URL}"
         _LOGGER.debug("Getting Data at: %s", data_access_url)
-        response = requests.get(data_access_url, headers=headers, cookies=cookies, params=params)
+        response = self.session.get(data_access_url, headers=headers, cookies=cookies, params=params)
 
         output = {
             "panel_production_power": 0.0,
@@ -791,7 +810,7 @@ class FusionSolarAPI:
          
         energy_balance_url = f"https://{self.data_host}{ENERGY_BALANCE_URL}?{urlencode(params)}"
         _LOGGER.debug("Getting Energy Balance at: %s", energy_balance_url)
-        energy_balance_response = requests.get(energy_balance_url, headers=headers, cookies=cookies)
+        energy_balance_response = self.session.get(energy_balance_url, headers=headers, cookies=cookies)
         _LOGGER.debug("Energy Balance Response: %s", energy_balance_response.text)
         try:
             energy_balance_data = energy_balance_response.json()
@@ -839,16 +858,29 @@ class FusionSolarAPI:
     def _renew_session(self) -> None:
         """Simulate session renewal."""
         _LOGGER.info("Renewing session.")
-        self.connected = False
-        self.dp_session = ""
-        self.login()
+        self.reset_session()
+        try:
+            self.login()
+        except APIAuthCaptchaError:
+            _LOGGER.error(
+                "Session renewal requires CAPTCHA. "
+                "Automated renewal is not possible. "
+                "Please reconfigure the integration."
+            )
+            self.connected = False
+        except Exception as ex:
+            _LOGGER.error("Session renewal failed: %s", ex)
+            self.connected = False
 
     def _session_monitor(self) -> None:
         """Monitor session and renew if needed."""
         while not self._stop_event.is_set():
-            if self.connected == False:
+            if not self.connected:
                 self._renew_session()
-            time.sleep(60)  # Check every 60 seconds
+                if not self.connected:
+                    _LOGGER.warning("Session monitor stopping: renewal failed")
+                    break
+            self._stop_event.wait(60)
 
     def _start_session_monitor(self) -> None:
         """Start the session monitor thread."""

--- a/custom_components/fusion_solar_app/api.py
+++ b/custom_components/fusion_solar_app/api.py
@@ -127,12 +127,15 @@ class FusionSolarAPI:
 
         # Pre-warm session: visit login page to get session cookies.
         # This mimics browser behavior and may avoid the CAPTCHA requirement.
-        login_page_url = f"https://{self.login_host}{LOGIN_FORM_URL}"
-        _LOGGER.debug("Pre-warming session by visiting login page: %s", login_page_url)
-        try:
-            self.session.get(login_page_url, timeout=20)
-        except Exception as ex:
-            _LOGGER.warning("Failed to pre-warm session: %s", ex)
+        # Skip pre-warm when retrying with a captcha answer, as it would reset
+        # the server-side session that the CAPTCHA is bound to.
+        if not self.captcha_input:
+            login_page_url = f"https://{self.login_host}{LOGIN_FORM_URL}"
+            _LOGGER.debug("Pre-warming session by visiting login page: %s", login_page_url)
+            try:
+                self.session.get(login_page_url, timeout=20)
+            except Exception as ex:
+                _LOGGER.warning("Failed to pre-warm session: %s", ex)
 
         public_key_url = f"https://{self.login_host}{PUBKEY_URL}"
         _LOGGER.debug("Getting Public Key at: %s", public_key_url)

--- a/custom_components/fusion_solar_app/config_flow.py
+++ b/custom_components/fusion_solar_app/config_flow.py
@@ -79,8 +79,7 @@ class FusionSolarConfigFlow(ConfigFlow, domain=DOMAIN):
     _stations: list[dict[str, Any]]
     _api: FusionSolarAPI | None = None
     _captcha_credentials: dict[str, Any] | None = None
-    _reauth_entry: ConfigEntry | None = None
-    _is_reauth: bool = False
+    _target_entry: ConfigEntry | None = None
 
     @staticmethod
     @callback
@@ -182,6 +181,23 @@ class FusionSolarConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    async def _finish_entry_update(
+        self, entry: ConfigEntry, credentials: dict[str, Any], api: FusionSolarAPI | None = None,
+    ) -> ConfigFlowResult:
+        """Update an existing config entry with new credentials/session and reload."""
+        update_data = {
+            **entry.data,
+            CONF_USERNAME: credentials[CONF_USERNAME],
+            CONF_PASSWORD: credentials[CONF_PASSWORD],
+            FUSION_SOLAR_HOST: credentials[FUSION_SOLAR_HOST],
+        }
+        if api and api.connected:
+            update_data["dp_session"] = api.dp_session
+            update_data["data_host"] = api.data_host
+        self.hass.config_entries.async_update_entry(entry, data=update_data)
+        await self.hass.config_entries.async_reload(entry.entry_id)
+        return self.async_abort(reason="reauth_successful")
+
     async def async_step_captcha(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -194,21 +210,10 @@ class FusionSolarConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 await self.hass.async_add_executor_job(self._api.login)
                 if self._api.connected:
-                    if self._is_reauth and self._reauth_entry:
-                        # Reauth flow: update existing config entry with session
-                        self.hass.config_entries.async_update_entry(
-                            self._reauth_entry,
-                            data={
-                                **self._reauth_entry.data,
-                                CONF_USERNAME: self._captcha_credentials[CONF_USERNAME],
-                                CONF_PASSWORD: self._captcha_credentials[CONF_PASSWORD],
-                                FUSION_SOLAR_HOST: self._captcha_credentials[FUSION_SOLAR_HOST],
-                                "dp_session": self._api.dp_session,
-                                "data_host": self._api.data_host,
-                            },
+                    if self._target_entry:
+                        return await self._finish_entry_update(
+                            self._target_entry, self._captcha_credentials, self._api,
                         )
-                        await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
-                        return self.async_abort(reason="reauth_successful")
 
                     # Normal flow: proceed to station selection
                     self._input_data = {**self._captcha_credentials}
@@ -251,7 +256,7 @@ class FusionSolarConfigFlow(ConfigFlow, domain=DOMAIN):
         self, entry_data: dict[str, Any]
     ) -> ConfigFlowResult:
         """Handle reauth when login fails at runtime."""
-        self._reauth_entry = self.hass.config_entries.async_get_entry(
+        self._target_entry = self.hass.config_entries.async_get_entry(
             self.context["entry_id"]
         )
         return await self.async_step_reauth_confirm()
@@ -272,30 +277,17 @@ class FusionSolarConfigFlow(ConfigFlow, domain=DOMAIN):
             except InvalidCaptcha as exc:
                 self._api = exc.api
                 self._captcha_credentials = user_input
-                self._is_reauth = True
                 return await self.async_step_captcha()
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception during reauth")
                 errors["base"] = "unknown"
 
             if "base" not in errors:
-                update_data = {
-                    **self._reauth_entry.data,
-                    CONF_USERNAME: user_input[CONF_USERNAME],
-                    CONF_PASSWORD: user_input[CONF_PASSWORD],
-                    FUSION_SOLAR_HOST: user_input[FUSION_SOLAR_HOST],
-                }
-                if api and api.connected:
-                    update_data["dp_session"] = api.dp_session
-                    update_data["data_host"] = api.data_host
-                self.hass.config_entries.async_update_entry(
-                    self._reauth_entry,
-                    data=update_data,
+                return await self._finish_entry_update(
+                    self._target_entry, user_input, api,
                 )
-                await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
-                return self.async_abort(reason="reauth_successful")
 
-        existing_data = self._reauth_entry.data if self._reauth_entry else {}
+        existing_data = self._target_entry.data if self._target_entry else {}
         return self.async_show_form(
             step_id="reauth_confirm",
             data_schema=vol.Schema(
@@ -333,8 +325,7 @@ class FusionSolarConfigFlow(ConfigFlow, domain=DOMAIN):
             except InvalidCaptcha as exc:
                 self._api = exc.api
                 self._captcha_credentials = user_input
-                self._reauth_entry = config_entry
-                self._is_reauth = True
+                self._target_entry = config_entry
                 return await self.async_step_captcha()
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception during reconfiguration")

--- a/custom_components/fusion_solar_app/config_flow.py
+++ b/custom_components/fusion_solar_app/config_flow.py
@@ -141,6 +141,11 @@ class FusionSolarConfigFlow(ConfigFlow, domain=DOMAIN):
 
             data = {**self._input_data, CONF_STATION_DN: station_dn}
 
+            # Persist authenticated session so coordinator can restore it
+            if self._api and self._api.connected:
+                data["dp_session"] = self._api.dp_session
+                data["data_host"] = self._api.data_host
+
             title = next(
                 (
                     station.get("stationName", "Fusion Solar App Integration")
@@ -190,7 +195,7 @@ class FusionSolarConfigFlow(ConfigFlow, domain=DOMAIN):
                 await self.hass.async_add_executor_job(self._api.login)
                 if self._api.connected:
                     if self._is_reauth and self._reauth_entry:
-                        # Reauth flow: update existing config entry
+                        # Reauth flow: update existing config entry with session
                         self.hass.config_entries.async_update_entry(
                             self._reauth_entry,
                             data={
@@ -198,6 +203,8 @@ class FusionSolarConfigFlow(ConfigFlow, domain=DOMAIN):
                                 CONF_USERNAME: self._captcha_credentials[CONF_USERNAME],
                                 CONF_PASSWORD: self._captcha_credentials[CONF_PASSWORD],
                                 FUSION_SOLAR_HOST: self._captcha_credentials[FUSION_SOLAR_HOST],
+                                "dp_session": self._api.dp_session,
+                                "data_host": self._api.data_host,
                             },
                         )
                         await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
@@ -272,14 +279,18 @@ class FusionSolarConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unknown"
 
             if "base" not in errors:
+                update_data = {
+                    **self._reauth_entry.data,
+                    CONF_USERNAME: user_input[CONF_USERNAME],
+                    CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    FUSION_SOLAR_HOST: user_input[FUSION_SOLAR_HOST],
+                }
+                if api and api.connected:
+                    update_data["dp_session"] = api.dp_session
+                    update_data["data_host"] = api.data_host
                 self.hass.config_entries.async_update_entry(
                     self._reauth_entry,
-                    data={
-                        **self._reauth_entry.data,
-                        CONF_USERNAME: user_input[CONF_USERNAME],
-                        CONF_PASSWORD: user_input[CONF_PASSWORD],
-                        FUSION_SOLAR_HOST: user_input[FUSION_SOLAR_HOST],
-                    },
+                    data=update_data,
                 )
                 await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
                 return self.async_abort(reason="reauth_successful")

--- a/custom_components/fusion_solar_app/config_flow.py
+++ b/custom_components/fusion_solar_app/config_flow.py
@@ -41,25 +41,34 @@ STEP_CAPTCHA_DATA_SCHEMA = vol.Schema(
 )
 
 
-async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+async def validate_input(
+    hass: HomeAssistant,
+    data: dict[str, Any],
+    api: FusionSolarAPI | None = None,
+) -> tuple[dict[str, Any], FusionSolarAPI]:
     """Validate the user input allows us to connect.
 
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
+    Returns a tuple of (info dict, api instance).
     """
-    api = FusionSolarAPI(data[CONF_USERNAME], data[CONF_PASSWORD], data[FUSION_SOLAR_HOST], data.get(CAPTCHA_INPUT, None))
+    if api is None:
+        api = FusionSolarAPI(data[CONF_USERNAME], data[CONF_PASSWORD], data[FUSION_SOLAR_HOST], data.get(CAPTCHA_INPUT, None))
+    else:
+        api.user = data[CONF_USERNAME]
+        api.pwd = data[CONF_PASSWORD]
+        api.login_host = data[FUSION_SOLAR_HOST]
+        api.captcha_input = data.get(CAPTCHA_INPUT, None)
+
     try:
         await hass.async_add_executor_job(api.login)
-        # If you cannot connect, raise CannotConnect
-        # If the authentication is wrong, raise InvalidAuth
     except APIAuthError as err:
         raise InvalidAuth from err
     except APIAuthCaptchaError as err:
-        raise InvalidCaptcha from err
+        raise InvalidCaptcha(api) from err
     except APIConnectionError as err:
         raise CannotConnect from err
 
-    # Return info that you want to store in the config entry.
-    return {"title": f"Fusion Solar App Integration"}
+    return {"title": f"Fusion Solar App Integration"}, api
 
 
 class FusionSolarConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -68,50 +77,43 @@ class FusionSolarConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     _input_data: dict[str, Any]
     _stations: list[dict[str, Any]]
+    _api: FusionSolarAPI | None = None
+    _captcha_credentials: dict[str, Any] | None = None
+    _reauth_entry: ConfigEntry | None = None
+    _is_reauth: bool = False
 
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
-        # Remove this method and the FusionSolarConfigFlow class
-        # if you do not want any options for your integration.
         return FusionSolarOptionsFlowHandler(config_entry)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        # Called when you initiate adding an integration via the UI
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            # The form has been filled in and submitted, so process the data provided.
             try:
-                # Validate that the setup data is valid and if not handle errors.
-                # The errors["base"] values match the values in your strings.json and translation files.
-                info = await validate_input(self.hass, user_input)
+                info, api = await validate_input(self.hass, user_input)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
-            except InvalidCaptcha:
-                _LOGGER.exception("Captcha failed, redirecting to Captcha screen")
-                return await self.async_step_captcha(user_input)
+            except InvalidCaptcha as exc:
+                _LOGGER.warning("Captcha required, redirecting to captcha screen")
+                self._api = exc.api
+                self._captcha_credentials = user_input
+                return await self.async_step_captcha()
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
 
             if "base" not in errors:
-                # Store validated input and fetch station list before proceeding
                 self._input_data = user_input
-                api = FusionSolarAPI(
-                    user_input[CONF_USERNAME],
-                    user_input[CONF_PASSWORD],
-                    user_input[FUSION_SOLAR_HOST],
-                    user_input.get(CAPTCHA_INPUT, None),
-                )
+                self._api = api
                 try:
-                    await self.hass.async_add_executor_job(api.login)
                     station_data = await self.hass.async_add_executor_job(api.get_station_list)
                     self._stations = station_data["data"]["list"]
                 except Exception:  # pylint: disable=broad-except
@@ -180,47 +182,118 @@ class FusionSolarConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle the captcha step."""
         errors: dict[str, str] = {}
-        captcha_img = ""
-        if user_input is not None:
+
+        if user_input is not None and CAPTCHA_INPUT in user_input:
+            # User submitted the captcha form
+            self._api.captcha_input = user_input[CAPTCHA_INPUT]
             try:
-                api = FusionSolarAPI(
-                    user_input[CONF_USERNAME],
-                    user_input[CONF_PASSWORD],
-                    user_input[FUSION_SOLAR_HOST],
-                    user_input.get(CAPTCHA_INPUT, None),
-                )
-                await self.hass.async_add_executor_job(api.login)
-                captcha_img = api.captcha_img if api.captcha_img else ""
-                if api.connected:
-                    # Login was successful after captcha, so save config data.
-                    unique_id = f"{user_input[CONF_USERNAME]}"
-                    await self.async_set_unique_id(unique_id, raise_on_progress=False)
-                    return self.async_create_entry(
-                        title="Fusion Solar App Integration", data=user_input
-                    )
+                await self.hass.async_add_executor_job(self._api.login)
+                if self._api.connected:
+                    if self._is_reauth and self._reauth_entry:
+                        # Reauth flow: update existing config entry
+                        self.hass.config_entries.async_update_entry(
+                            self._reauth_entry,
+                            data={
+                                **self._reauth_entry.data,
+                                CONF_USERNAME: self._captcha_credentials[CONF_USERNAME],
+                                CONF_PASSWORD: self._captcha_credentials[CONF_PASSWORD],
+                                FUSION_SOLAR_HOST: self._captcha_credentials[FUSION_SOLAR_HOST],
+                            },
+                        )
+                        await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
+                        return self.async_abort(reason="reauth_successful")
+
+                    # Normal flow: proceed to station selection
+                    self._input_data = {**self._captcha_credentials}
+                    try:
+                        station_data = await self.hass.async_add_executor_job(self._api.get_station_list)
+                        self._stations = station_data["data"]["list"]
+                    except Exception:  # pylint: disable=broad-except
+                        _LOGGER.exception("Failed to fetch station list after captcha login")
+                        errors["base"] = "cannot_connect"
+                    else:
+                        return await self.async_step_select_station()
                 else:
                     errors["base"] = "invalid_captcha"
             except APIAuthCaptchaError:
+                # Wrong captcha or expired — API already fetched a new captcha image
                 errors["base"] = "invalid_captcha"
-            except CannotConnect:
-                errors["base"] = "cannot_connect"
-            except InvalidAuth:
+            except APIAuthError:
                 errors["base"] = "invalid_auth"
+            except APIConnectionError:
+                errors["base"] = "cannot_connect"
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception during captcha handling")
                 errors["base"] = "unknown"
 
+        # Show captcha form
+        captcha_img = ""
+        if self._api and self._api.captcha_img:
+            captcha_img = self._api.captcha_img
+
         return self.async_show_form(
             step_id="captcha",
+            data_schema=STEP_CAPTCHA_DATA_SCHEMA,
+            description_placeholders={
+                "captcha_img": f'<img id="fusion_solar_app_security_captcha" src="{captcha_img}"/>'
+            },
+            errors=errors,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: dict[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle reauth when login fails at runtime."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reauth confirmation step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                info, api = await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except InvalidCaptcha as exc:
+                self._api = exc.api
+                self._captcha_credentials = user_input
+                self._is_reauth = True
+                return await self.async_step_captcha()
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception during reauth")
+                errors["base"] = "unknown"
+
+            if "base" not in errors:
+                self.hass.config_entries.async_update_entry(
+                    self._reauth_entry,
+                    data={
+                        **self._reauth_entry.data,
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                        FUSION_SOLAR_HOST: user_input[FUSION_SOLAR_HOST],
+                    },
+                )
+                await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+
+        existing_data = self._reauth_entry.data if self._reauth_entry else {}
+        return self.async_show_form(
+            step_id="reauth_confirm",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_USERNAME, default=user_input[CONF_USERNAME]): str,
-                    vol.Required(CONF_PASSWORD, default=user_input[CONF_PASSWORD]): str,
-                    vol.Required(FUSION_SOLAR_HOST, default=user_input[FUSION_SOLAR_HOST]): str,
-                    vol.Required(CAPTCHA_INPUT): str,
+                    vol.Required(CONF_USERNAME, default=existing_data.get(CONF_USERNAME, "")): str,
+                    vol.Required(CONF_PASSWORD): str,
+                    vol.Required(FUSION_SOLAR_HOST, default=existing_data.get(FUSION_SOLAR_HOST, "")): str,
                 }
             ),
-            description_placeholders={"captcha_img": '<img id="fusion_solar_app_security_captcha" src="' + captcha_img + '"/>'},
             errors=errors,
         )
 
@@ -230,29 +303,32 @@ class FusionSolarConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle reconfiguration of Fusion Solar App Integration."""
         errors: dict[str, str] = {}
-    
+
         entry_id = self.context.get("entry_id")
         if not entry_id:
             return self.async_abort(reason="missing_entry_id")
-    
+
         config_entry = self.hass.config_entries.async_get_entry(entry_id)
         if config_entry is None:
             return self.async_abort(reason="config_entry_not_found")
-    
+
         if user_input is not None:
             try:
-                # Validate the new credentials
-                await validate_input(self.hass, user_input)
+                info, api = await validate_input(self.hass, user_input)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
-            except InvalidCaptcha:
-                errors["base"] = "invalid_captcha"
+            except InvalidCaptcha as exc:
+                self._api = exc.api
+                self._captcha_credentials = user_input
+                self._reauth_entry = config_entry
+                self._is_reauth = True
+                return await self.async_step_captcha()
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception during reconfiguration")
                 errors["base"] = "unknown"
-    
+
             if "base" not in errors:
                 # Update the existing config entry with new data
                 self.hass.config_entries.async_update_entry(
@@ -266,7 +342,7 @@ class FusionSolarConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
                 await self.hass.config_entries.async_reload(config_entry.entry_id)
                 return self.async_abort(reason="reconfigure_successful")
-    
+
         return self.async_show_form(
             step_id="reconfigure",
             data_schema=vol.Schema(
@@ -305,10 +381,7 @@ class FusionSolarOptionsFlowHandler(OptionsFlow):
         if user_input is not None:
             options = self._config_entry.options | user_input
             return self.async_create_entry(title="", data=options)
-    
-        # It is recommended to prepopulate options fields with default values if available.
-        # These will be the same default values you use on your coordinator for setting variable values
-        # if the option has not been set.
+
         data_schema = vol.Schema(
             {
                 vol.Required(
@@ -317,7 +390,7 @@ class FusionSolarOptionsFlowHandler(OptionsFlow):
                 ): (vol.All(vol.Coerce(int), vol.Clamp(min=MIN_SCAN_INTERVAL))),
             }
         )
-    
+
         return self.async_show_form(step_id="init", data_schema=data_schema)
 
 
@@ -328,4 +401,7 @@ class InvalidAuth(HomeAssistantError):
     """Error to indicate there is invalid auth."""
 
 class InvalidCaptcha(HomeAssistantError):
-    """Error to indicate there is invalid captcha."""
+    """Error to indicate captcha is required."""
+    def __init__(self, api: FusionSolarAPI | None = None):
+        super().__init__("Captcha required")
+        self.api = api

--- a/custom_components/fusion_solar_app/coordinator.py
+++ b/custom_components/fusion_solar_app/coordinator.py
@@ -11,9 +11,10 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .api import FusionSolarAPI, APIAuthError, Device, DeviceType
+from .api import FusionSolarAPI, APIAuthError, APIAuthCaptchaError, Device, DeviceType
 from .const import DEFAULT_SCAN_INTERVAL, FUSION_SOLAR_HOST, CAPTCHA_INPUT, CONF_STATION_DN, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,7 +41,7 @@ class FusionSolarCoordinator(DataUpdateCoordinator):
         self.user = config_entry.data[CONF_USERNAME]
         self.pwd = config_entry.data[CONF_PASSWORD]
         self.login_host = config_entry.data[FUSION_SOLAR_HOST]
-        self.captcha_input = config_entry.data.get("CAPTCHA_INPUT", None)
+        self.captcha_input = None
 
         # set variables from options.  You need a default here incase options have not been set
         self.poll_interval = config_entry.options.get(
@@ -62,7 +63,7 @@ class FusionSolarCoordinator(DataUpdateCoordinator):
         )
 
         # Initialise your api here
-        self.api = FusionSolarAPI(user=self.user, pwd=self.pwd, login_host=self.login_host, captcha_input=self.captcha_input)
+        self.api = FusionSolarAPI(user=self.user, pwd=self.pwd, login_host=self.login_host, captcha_input=None)
         self.api.station = config_entry.data.get(CONF_STATION_DN)
 
     async def async_update_data(self):
@@ -75,12 +76,23 @@ class FusionSolarCoordinator(DataUpdateCoordinator):
             if not self.api.connected:
                 await self.hass.async_add_executor_job(self.api.login)
             devices = await self.hass.async_add_executor_job(self.api.get_devices)
+        except APIAuthCaptchaError as err:
+            raise ConfigEntryAuthFailed(
+                "Login requires CAPTCHA. Please reconfigure the integration."
+            ) from err
         except APIAuthError as err:
-            _LOGGER.error(err)
-            await self.hass.async_add_executor_job(self.api.login)
-            devices = await self.hass.async_add_executor_job(self.api.get_devices) 
+            _LOGGER.warning("Auth error, attempting re-login: %s", err)
+            try:
+                self.api.reset_session()
+                await self.hass.async_add_executor_job(self.api.login)
+                devices = await self.hass.async_add_executor_job(self.api.get_devices)
+            except APIAuthCaptchaError as captcha_err:
+                raise ConfigEntryAuthFailed(
+                    "Login requires CAPTCHA. Please reconfigure the integration."
+                ) from captcha_err
+            except Exception as retry_err:
+                raise UpdateFailed(f"Re-login failed: {retry_err}") from retry_err
         except Exception as err:
-            # This will show entities as unavailable by raising UpdateFailed exception
             _LOGGER.error(err)
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 

--- a/custom_components/fusion_solar_app/coordinator.py
+++ b/custom_components/fusion_solar_app/coordinator.py
@@ -66,6 +66,16 @@ class FusionSolarCoordinator(DataUpdateCoordinator):
         self.api = FusionSolarAPI(user=self.user, pwd=self.pwd, login_host=self.login_host, captcha_input=None)
         self.api.station = config_entry.data.get(CONF_STATION_DN)
 
+        # Restore authenticated session from config entry if available
+        dp_session = config_entry.data.get("dp_session")
+        data_host = config_entry.data.get("data_host")
+        if dp_session and data_host:
+            try:
+                self.api.restore_session(dp_session, data_host)
+                _LOGGER.info("Restored authenticated session from config entry")
+            except Exception as ex:
+                _LOGGER.warning("Failed to restore session, will login fresh: %s", ex)
+
     async def async_update_data(self):
         """Fetch data from API endpoint.
 

--- a/custom_components/fusion_solar_app/strings.json
+++ b/custom_components/fusion_solar_app/strings.json
@@ -3,13 +3,15 @@
     "title": "Fusion Solar App Integration",
     "abort": {
       "already_configured": "Device is already configured",
-      "reconfigure_successful": "Reconfiguration successful"
+      "reconfigure_successful": "Reconfiguration successful",
+      "reauth_successful": "Re-authentication successful"
     },
     "error": {
       "cannot_connect": "Failed to connect",
       "invalid_auth": "Invalid authentication",
       "unknown": "Unexpected error",
-      "captcha_required": "Captcha required"
+      "captcha_required": "Captcha required",
+      "invalid_captcha": "Invalid captcha. Please try again."
     },
     "step": {
       "user": {
@@ -31,6 +33,15 @@
         "description": "{captcha_img}",
         "data": {
           "captcha_input": "Captcha"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate Fusion Solar",
+        "description": "Your session has expired and requires re-authentication.",
+        "data": {
+          "username": "Username",
+          "password": "Password",
+          "fusion_solar_host": "Fusion Solar Login Host"
         }
       }
     }

--- a/custom_components/fusion_solar_app/translations/en.json
+++ b/custom_components/fusion_solar_app/translations/en.json
@@ -3,13 +3,15 @@
     "title": "Fusion Solar App Integration",
     "abort": {
       "already_configured": "Device is already configured",
-      "reconfigure_successful": "Reconfiguration successful"
+      "reconfigure_successful": "Reconfiguration successful",
+      "reauth_successful": "Re-authentication successful"
     },
     "error": {
       "cannot_connect": "Failed to connect",
       "invalid_auth": "Invalid authentication",
       "unknown": "Unexpected error",
-      "captcha_required": "Captcha required"
+      "captcha_required": "Captcha required",
+      "invalid_captcha": "Invalid captcha. Please try again."
     },
     "step": {
       "user": {
@@ -31,6 +33,15 @@
         "description": "{captcha_img}",
         "data": {
           "captcha_input": "Captcha"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate Fusion Solar",
+        "description": "Your session has expired and requires re-authentication.",
+        "data": {
+          "username": "Username",
+          "password": "Password",
+          "fusion_solar_host": "Fusion Solar Login Host"
         }
       }
     }


### PR DESCRIPTION
## Summary

- **Fix CAPTCHA login flow** — resolves issue #31 by properly handling the CAPTCHA challenge during authentication. When a CAPTCHA is required, the user is prompted to solve it within the config flow.
- **Skip session pre-warm on captcha retry** — avoids triggering a new CAPTCHA when the user is already providing a CAPTCHA answer.
- **Persist authenticated session** — reuses the session established during the config flow in the coordinator, preventing a redundant login after setup.

## Changes

- `api.py` — Added CAPTCHA detection and handling in the login flow
- `config_flow.py` — Extended config flow with a CAPTCHA step that presents the challenge to the user
- `coordinator.py` — Accept and reuse an existing authenticated session from config flow
- `__init__.py` — Pass session through from config entry setup to coordinator
- `strings.json` / `translations/en.json` — Added CAPTCHA-related UI strings