### PR TITLE
Add 3-phase inverter voltage and current sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,12 @@ After setting up the Integration you will get a Device which will have the follo
 The following sensors are fetched directly from the inverter device and require the inverter to be reachable via the API:
 
 * Inverter Grid Voltage (V)
-* Inverter Grid Current (A)
+* Inverter Grid Current (A, phase A on 3-phase systems)
+* Inverter Phase A Voltage (V)
+* Inverter Phase B Voltage (V)
+* Inverter Phase C Voltage (V)
+* Inverter Phase B Current (A)
+* Inverter Phase C Current (A)
 * Inverter Grid Frequency (Hz)
 * Inverter Internal Temperature (°C)
 * Inverter Insulation Resistance (MΩ)

--- a/custom_components/fusion_solar_app/api.py
+++ b/custom_components/fusion_solar_app/api.py
@@ -92,7 +92,12 @@ DEVICES = [
 # Signal ID -> sensor definition for inverter real-time data
 INVERTER_SIGNAL_MAP = {
     10008: {"id": "Inverter Grid Voltage", "type": DeviceType.SENSOR_VOLTAGE, "icon": "mdi:flash"},
+    10011: {"id": "Inverter Phase A Voltage", "type": DeviceType.SENSOR_VOLTAGE, "icon": "mdi:flash"},
+    10012: {"id": "Inverter Phase B Voltage", "type": DeviceType.SENSOR_VOLTAGE, "icon": "mdi:flash"},
+    10013: {"id": "Inverter Phase C Voltage", "type": DeviceType.SENSOR_VOLTAGE, "icon": "mdi:flash"},
     10014: {"id": "Inverter Grid Current", "type": DeviceType.SENSOR_CURRENT, "icon": "mdi:current-ac"},
+    10015: {"id": "Inverter Phase B Current", "type": DeviceType.SENSOR_CURRENT, "icon": "mdi:current-ac"},
+    10016: {"id": "Inverter Phase C Current", "type": DeviceType.SENSOR_CURRENT, "icon": "mdi:current-ac"},
     10021: {"id": "Inverter Grid Frequency", "type": DeviceType.SENSOR_FREQUENCY, "icon": "mdi:sine-wave"},
     10023: {"id": "Inverter Internal Temperature", "type": DeviceType.SENSOR_TEMPERATURE, "icon": "mdi:thermometer"},
     10024: {"id": "Inverter Insulation Resistance", "type": DeviceType.SENSOR_RESISTANCE, "icon": "mdi:omega"},


### PR DESCRIPTION
## Summary
- add 3-phase inverter voltage sensors for signal IDs `10011`, `10012`, and `10013`
- add 3-phase inverter current sensors for signal IDs `10015` and `10016`
- keep signal ID `10014` mapped to the existing `Inverter Grid Current` entity to avoid breaking existing
installations
- update the README to document the additional sensors and clarify that grid current is phase A on 3-phase systems

## Context
Some inverters on 3-phase electrical systems do not report grid voltage under signal ID `10008`, and signal ID `10014`
represents phase A current rather than total grid current.

Closes #37 